### PR TITLE
Fix Windows build

### DIFF
--- a/README
+++ b/README
@@ -23,6 +23,14 @@ Dependencies
 Building the library
 ----------------------------------------------
 
+On Windows, follow the instructions here to set up your environment:
+http://rexdouglass.com/python-64-bit-on-windows-part-2-building-packages/
+
+Then to create a wheel package, run the following command:
+python setup.py bdist_wheel
+This will create a .whl package in dist/ directory which can then be redistributed.
+
+On Linux, you can do:
 python setup.py build_ext -i
 
 ----------------------------------------------

--- a/poly2tri/sweep/sweep.cc
+++ b/poly2tri/sweep/sweep.cc
@@ -28,11 +28,15 @@
  * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+
+#define _USE_MATH_DEFINES
+
 #include "sweep.h"
 #include "sweep_context.h"
 #include "advancing_front.h"
 #include "../common/utils.h"
 #include <cstdio>
+#include <cmath>
 #include <exception>
 
 


### PR DESCRIPTION
This fixes Windows build by adding a missing include and define.
The readme is also updated to indicate how to build on Windows.
